### PR TITLE
Inkscape 1.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Always check if the returned values are sound with respect to what is reported i
 
 ## Installation
 
-I assume you already have Inkscape installed.
+I assume you already have Inkscape installed. This extension is compatible with Inkscape for version 1.0 and higher.
 
 Close Inkscape.
 Copy the two files (`toXY.inx` and `toXY.py`) into the extensions directory of Inkscape, which is usually located:

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ For example, I copied the data into Excel and, after a minor clean up, I have go
 
 ![](https://github.com/aesuli/toXY/blob/main/PdfConvert8.png?raw=true)
 
+Optionally you can also output the contents of the box to a file which uses the same formatting as the text box. 
+
 ## License
 
 Copyright 2021 Andrea Esuli <andrea@esuli.it>

--- a/toXY.inx
+++ b/toXY.inx
@@ -3,12 +3,15 @@
   <id>org.ekips.filter.toXY</id>
   <dependency type="executable" location="extensions">toXY.py</dependency>
   <dependency type="executable" location="extensions">inkex.py</dependency>
-  <param name="title" type="description">This effect converts a path into XY coordinates. Useful to extract number values out of graphs."</param>
+  <param name="title" type="description">This effect converts the nodes of a path into XY coordinates. Useful to extract number values out of graphs.</param>
   <param name="xmin" type="float" min="-1e+37" max="1e+37" precision="4" _gui-text="x min (lower left corner)">0.0</param>  
   <param name="ymin" type="float" min="-1e+37" max="1e+37" precision="4" _gui-text="y min (lower left corner)">0.0</param>  
   <param name="xmax" type="float" min="-1e+37" max="1e+37" precision="4" _gui-text="x max (upper right corner)">1.0</param>  
   <param name="ymax" type="float" min="-1e+37" max="1e+37" precision="4" _gui-text="y max (upper right corner)">1.0</param>  
-  <param name="fontsize" type="int" min="1" max="1000" _gui-text="font size">10</param>  
+  <param name="fontsize" type="int" min="1" max="1000" _gui-text="font size">10</param>
+  <separator />
+  <param name="write_output_file" type="boolean" gui-text="Write to output file?">false</param>
+  <param type="path" name="output_file" gui-text="output file path" mode="file_new" [filetypes="$filetypes"]/>
 <effect>
     <object-type>path</object-type>
     <effects-menu>

--- a/toXY.py
+++ b/toXY.py
@@ -9,137 +9,137 @@ import simplestyle
 """ Inkscape extension that extracts XY coordinates of points defining selected paths. """
 class ToXYEffect(inkex.Effect):
 
-	""" Constructor. """
-	def __init__(self):
-		# Call base class construtor.
-		inkex.Effect.__init__(self)
-        	self.OptionParser.add_option("--xmin",
-           	action="store", type="float", 
-                	dest="xmin", default=0.0,
-                help="x min (lower left corner)")
-        	self.OptionParser.add_option("--ymin",
-           	action="store", type="float", 
-                	dest="ymin", default=0.0,
-                help="y min (lower left corner)")
-        	self.OptionParser.add_option("--xmax",
-           	action="store", type="float", 
-                	dest="xmax", default=1.0,
-                help="x max (upper right corner)")
-        	self.OptionParser.add_option("--ymax",
-           	action="store", type="float", 
-                	dest="ymax", default=1.0,
-                help="y max (upper right corner)")
-        	self.OptionParser.add_option("--fontsize",
-           	action="store", type="float", 
-                	dest="fontSize", default=10.0,
-                help="Font size")
+    """ Constructor. """
+    def __init__(self):
+        # Call base class construtor.
+        inkex.Effect.__init__(self)
+        self.OptionParser.add_option("--xmin",
+            action="store", type="float", 
+                dest="xmin", default=0.0,
+            help="x min (lower left corner)")
+        self.OptionParser.add_option("--ymin",
+            action="store", type="float", 
+                dest="ymin", default=0.0,
+            help="y min (lower left corner)")
+        self.OptionParser.add_option("--xmax",
+            action="store", type="float", 
+                dest="xmax", default=1.0,
+            help="x max (upper right corner)")
+        self.OptionParser.add_option("--ymax",
+            action="store", type="float", 
+                dest="ymax", default=1.0,
+            help="y max (upper right corner)")
+        self.OptionParser.add_option("--fontsize",
+            action="store", type="float", 
+                dest="fontSize", default=10.0,
+            help="Font size")
 
-	""" Draw a rectangle """
-	def draw_rect(self, (x,y), (w,h), parent):
-    		style = {   
-			'stroke'        : '#000000',
-			'stroke-opacity' : '1',
-        		'width'         : '1',
+    """ Draw a rectangle """
+    def draw_rect(self, (x,y), (w,h), parent):
+            style = {   
+            'stroke'        : '#000000',
+            'stroke-opacity' : '1',
+                'width'         : '1',
                 'fill'          : 'none'
            }
-    		attribs = {
-        		'style'     : simplestyle.formatStyle(style),
-        		'height'    : str(h),
-        		'width'     : str(w),
-        		'x'         : str(x),
-        		'y'         : str(y)
+            attribs = {
+                'style'     : simplestyle.formatStyle(style),
+                'height'    : str(h),
+                'width'     : str(w),
+                'x'         : str(x),
+                'y'         : str(y)
            }
-	    	inkex.etree.SubElement(parent, inkex.addNS('rect','svg'), attribs )
+            inkex.etree.SubElement(parent, inkex.addNS('rect','svg'), attribs )
 
-	""" Write some text, breaking lines on \'\\n\' """
-	def write_text(self, (x,y), text, parent):
-    		style = {   
-			'font-size'	: self.options.fontSize,
-			'font-style'	: 'normal',
-			'font-weight'	: 'normal',
-			'fill'	: '#000000',
-			'fill-opacity' : '1',
-			'stroke' : 'none',
-                'font-family':'Sans'
-           }
-    		attribs = {
-        		'style'     : simplestyle.formatStyle(style),
-        		'x'         : str(x),
-        		'y'         : str(y)
-           }
-	    	textNode = inkex.etree.SubElement(parent, inkex.addNS('text','svg'), attribs )
-		for line in text.split('\n'):
-	          	tspan = inkex.etree.Element(inkex.addNS("tspan", "svg"))
-	          	tspan.set(inkex.addNS("role","sodipodi"), "line")
-	          	tspan.text = line
-          		textNode.append(tspan)
+    """ Write some text, breaking lines on \'\\n\' """
+    def write_text(self, (x,y), text, parent):
+        style = {   
+        'font-size'    : self.options.fontSize,
+        'font-style'    : 'normal',
+        'font-weight'    : 'normal',
+        'fill'    : '#000000',
+        'fill-opacity' : '1',
+        'stroke' : 'none',
+            'font-family':'Sans'
+        }
+        attribs = {
+            'style'     : simplestyle.formatStyle(style),
+            'x'         : str(x),
+            'y'         : str(y)
+        }
+            textNode = inkex.etree.SubElement(parent, inkex.addNS('text','svg'), attribs )
+        for line in text.split('\n'):
+                  tspan = inkex.etree.Element(inkex.addNS("tspan", "svg"))
+                  tspan.set(inkex.addNS("role","sodipodi"), "line")
+                  tspan.text = line
+                  textNode.append(tspan)
 
-	""" Recursively extract paths. """
-	def extractPath(self,node,points,transformMatrix=None):
-		pathString = node.get('d')
-		if pathString:
-			id = node.get('id')
-			path = cubicsuperpath.parsePath(node.get('d'))
-			if transformMatrix:
-				simpletransform.applyTransformToPath(transformMatrix,path)
-			# reflection on y axys to have y growing toward up direction of the graph
-			points[id] = [point[1] for segment in path for point in segment]
-			points[id] = [(x,-y) for (x,y) in points[id]]
-		elif node.tag==inkex.addNS('g','svg'):
-			innerTransform = node.get('transform')
-			innerTransformMatrix = simpletransform.parseTransform(innerTransform)
-			if innerTransformMatrix:
-				if(transformMatrix):
-					transformMatrix = simpletransform.composeTransform(transformMatrix,innerTransformMatrix)
-				else:
-					transformMatrix = innerTransformMatrix
-			for child in node.iterchildren():
-				self.extractPath(child,points,transformMatrix)
-		else:
-			inkex.debug(node.tag)
+    """ Recursively extract paths. """
+    def extractPath(self,node,points,transformMatrix=None):
+        pathString = node.get('d')
+        if pathString:
+            id = node.get('id')
+            path = cubicsuperpath.parsePath(node.get('d'))
+            if transformMatrix:
+                simpletransform.applyTransformToPath(transformMatrix,path)
+            # reflection on y axys to have y growing toward up direction of the graph
+            points[id] = [point[1] for segment in path for point in segment]
+            points[id] = [(x,-y) for (x,y) in points[id]]
+        elif node.tag==inkex.addNS('g','svg'):
+            innerTransform = node.get('transform')
+            innerTransformMatrix = simpletransform.parseTransform(innerTransform)
+            if innerTransformMatrix:
+                if(transformMatrix):
+                    transformMatrix = simpletransform.composeTransform(transformMatrix,innerTransformMatrix)
+                else:
+                    transformMatrix = innerTransformMatrix
+            for child in node.iterchildren():
+                self.extractPath(child,points,transformMatrix)
+        else:
+            inkex.debug(node.tag)
 
-	""" toXY effect. """
-	def effect(self):
-		if len(self.selected)<1:
-			inkex.debug("This extension requires that you select at least one path.")
-			return
+    """ toXY effect. """
+    def effect(self):
+        if len(self.selected)<1:
+            inkex.debug("This extension requires that you select at least one path.")
+            return
 
-		xrange = self.options.xmax-self.options.xmin
-		yrange = self.options.ymax-self.options.ymin
-		if xrange<=0 or yrange<=0:
-			inkex.debug("Negative ranges, check x-y min-max values.")
-			return
+        xrange = self.options.xmax-self.options.xmin
+        yrange = self.options.ymax-self.options.ymin
+        if xrange<=0 or yrange<=0:
+            inkex.debug("Negative ranges, check x-y min-max values.")
+            return
 
-		#gathering points from paths
-		points = {}
-		for id in self.options.ids:
-			node = self.selected[id]
-			self.extractPath(node,points)
+        #gathering points from paths
+        points = {}
+        for id in self.options.ids:
+            node = self.selected[id]
+            self.extractPath(node,points)
 
-		if not points:
-			inkex.debug("No paths found.")
-			return
+        if not points:
+            inkex.debug("No paths found.")
+            return
 
-		#boundaries
-		xmin = min([point[0] for pointset in points.values() for point in pointset])
-		ymin = min([point[1] for pointset in points.values() for point in pointset])
+        #boundaries
+        xmin = min([point[0] for pointset in points.values() for point in pointset])
+        ymin = min([point[1] for pointset in points.values() for point in pointset])
 
-		xdelta = max([point[0] for pointset in points.values() for point in pointset])-xmin
-		ydelta = max([point[1] for pointset in points.values() for point in pointset])-ymin
-		
-		#converting coordinates writing table
-		table = "pathId x y\n"
-		for id in points.keys():
-			points[id] = [((((x-xmin)/xdelta)*xrange)+self.options.xmin,(((y-ymin)/ydelta)*yrange)+self.options.ymin) for (x,y) in points[id]]
-			table += "\n".join(['{0} {1:4g} {2:4g}'.format(id,x,y) for (x,y) in points[id]])
-			table += "\n"
+        xdelta = max([point[0] for pointset in points.values() for point in pointset])-xmin
+        ydelta = max([point[1] for pointset in points.values() for point in pointset])-ymin
+        
+        #converting coordinates writing table
+        table = "pathId x y\n"
+        for id in points.keys():
+            points[id] = [((((x-xmin)/xdelta)*xrange)+self.options.xmin,(((y-ymin)/ydelta)*yrange)+self.options.ymin) for (x,y) in points[id]]
+            table += "\n".join(['{0} {1:4g} {2:4g}'.format(id,x,y) for (x,y) in points[id]])
+            table += "\n"
 
-		#output
-		group = inkex.etree.SubElement(self.current_layer, inkex.addNS('g','svg'))
-		self.draw_rect((xmin,-ymin-ydelta),(xdelta,ydelta),group)
-		self.write_text((xmin,-ymin+self.options.fontSize),"{0:4g},{1:4g}".format(self.options.xmin,self.options.ymin),group)
-		self.write_text((xmin+xdelta,-ymin-ydelta),"{0:4g},{1:4g}".format(self.options.xmax,self.options.ymax),group)
-		self.write_text((xmin,-ymin+self.options.fontSize*2.5 ),table,group)
+        #output
+        group = inkex.etree.SubElement(self.current_layer, inkex.addNS('g','svg'))
+        self.draw_rect((xmin,-ymin-ydelta),(xdelta,ydelta),group)
+        self.write_text((xmin,-ymin+self.options.fontSize),"{0:4g},{1:4g}".format(self.options.xmin,self.options.ymin),group)
+        self.write_text((xmin+xdelta,-ymin-ydelta),"{0:4g},{1:4g}".format(self.options.xmax,self.options.ymax),group)
+        self.write_text((xmin,-ymin+self.options.fontSize*2.5 ),table,group)
 
 e = ToXYEffect()
 e.affect()

--- a/toXY.py
+++ b/toXY.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+import sys
+print(sys.path)
+
 import inkex
 import cubicsuperpath
 import simpletransform
@@ -35,7 +38,7 @@ class ToXYEffect(inkex.Effect):
             help="Font size")
 
     """ Draw a rectangle """
-    def draw_rect(self, (x,y), (w,h), parent):
+    def draw_rect(self, x, y, w, h, parent):
             style = {   
             'stroke'        : '#000000',
             'stroke-opacity' : '1',
@@ -52,7 +55,7 @@ class ToXYEffect(inkex.Effect):
             inkex.etree.SubElement(parent, inkex.addNS('rect','svg'), attribs )
 
     """ Write some text, breaking lines on \'\\n\' """
-    def write_text(self, (x,y), text, parent):
+    def write_text(self, x, y, text, parent):
         style = {   
         'font-size'    : self.options.fontSize,
         'font-style'    : 'normal',
@@ -67,7 +70,7 @@ class ToXYEffect(inkex.Effect):
             'x'         : str(x),
             'y'         : str(y)
         }
-            textNode = inkex.etree.SubElement(parent, inkex.addNS('text','svg'), attribs )
+        textNode = inkex.etree.SubElement(parent, inkex.addNS('text','svg'), attribs )
         for line in text.split('\n'):
                   tspan = inkex.etree.Element(inkex.addNS("tspan", "svg"))
                   tspan.set(inkex.addNS("role","sodipodi"), "line")
@@ -136,10 +139,10 @@ class ToXYEffect(inkex.Effect):
 
         #output
         group = inkex.etree.SubElement(self.current_layer, inkex.addNS('g','svg'))
-        self.draw_rect((xmin,-ymin-ydelta),(xdelta,ydelta),group)
-        self.write_text((xmin,-ymin+self.options.fontSize),"{0:4g},{1:4g}".format(self.options.xmin,self.options.ymin),group)
-        self.write_text((xmin+xdelta,-ymin-ydelta),"{0:4g},{1:4g}".format(self.options.xmax,self.options.ymax),group)
-        self.write_text((xmin,-ymin+self.options.fontSize*2.5 ),table,group)
+        self.draw_rect(xmin, -ymin-ydelta, xdelta, ydelta,group)
+        self.write_text(xmin,-ymin+self.options.fontSize,"{0:4g},{1:4g}".format(self.options.xmin,self.options.ymin),group)
+        self.write_text(xmin+xdelta, -ymin-ydelta,"{0:4g},{1:4g}".format(self.options.xmax,self.options.ymax),group)
+        self.write_text(xmin, -ymin+self.options.fontSize*2.5, table,group)
 
 e = ToXYEffect()
 e.affect()

--- a/toXY.py
+++ b/toXY.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+""" Inkscape extension that extracts XY coordinates of points defining selected paths. """
 
 import pathlib
 from lxml import etree
@@ -7,10 +8,10 @@ from inkex.transforms import Transform
 from inkex.paths import Path
 
 
-""" Inkscape extension that extracts XY coordinates of points defining selected paths. """
 class ToXYEffect(inkex.Effect):
 
-    """ Constructor. """
+    """Constructor."""
+
     def __init__(self):
         # Call base class construtor.
         inkex.Effect.__init__(self)
@@ -71,81 +72,79 @@ class ToXYEffect(inkex.Effect):
             help="Optional output file",
         )
 
-    """ Draw a rectangle """
     def draw_rect(self, x, y, w, h, parent):
-            style = {   
-            'stroke'        : '#000000',
-            'stroke-opacity' : '1',
-                'width'         : '1',
-                'fill'          : 'none'
-           }
-            attribs = {
-                'style'     : str(inkex.Style(style)),
-                'height'    : str(h),
-                'width'     : str(w),
-                'x'         : str(x),
-                'y'         : str(y)
-           }
-            etree.SubElement(parent, inkex.addNS('rect','svg'), attribs )
-
-    """ Write some text, breaking lines on \'\\n\' """
-    def write_text(self, x, y, text, parent):
-        style = {   
-        'font-size'    : self.options.fontSize,
-        'font-style'    : 'normal',
-        'font-weight'    : 'normal',
-        'fill'    : '#000000',
-        'fill-opacity' : '1',
-        'stroke' : 'none',
-            'font-family':'Sans'
+        """Draw a rectangle"""
+        style = {
+            "stroke": "#000000",
+            "stroke-opacity": "1",
+            "width": "1",
+            "fill": "none",
         }
         attribs = {
-            'style'     : str(inkex.Style(style)),
-            'x'         : str(x),
-            'y'         : str(y)
+            "style": str(inkex.Style(style)),
+            "height": str(h),
+            "width": str(w),
+            "x": str(x),
+            "y": str(y),
         }
-        textNode = etree.SubElement(parent, inkex.addNS('text','svg'), attribs )
-        for line in text.split('\n'):
-                  tspan = etree.Element(inkex.addNS("tspan", "svg"))
-                  tspan.set(inkex.addNS("role","sodipodi"), "line")
-                  tspan.text = line
-                  textNode.append(tspan)
+        etree.SubElement(parent, inkex.addNS("rect", "svg"), attribs)
 
-    """ Recursively extract paths. """
-    def extractPath(self,node,points,transform=None):
-        pathString = node.get('d')
+    def write_text(self, x, y, text, parent):
+        """Write some text, breaking lines on \'\\n\'"""
+        style = {
+            "font-size": self.options.fontSize,
+            "font-style": "normal",
+            "font-weight": "normal",
+            "fill": "#000000",
+            "fill-opacity": "1",
+            "stroke": "none",
+            "font-family": "Sans",
+        }
+        attribs = {"style": str(inkex.Style(style)), "x": str(x), "y": str(y)}
+        text_node = etree.SubElement(parent, inkex.addNS("text", "svg"), attribs)
+        for line in text.split("\n"):
+            tspan = etree.Element(inkex.addNS("tspan", "svg"))
+            tspan.set(inkex.addNS("role", "sodipodi"), "line")
+            tspan.text = line
+            text_node.append(tspan)
+
+    def extract_path(self, node, points, transform=None):
+        """Recursively extract paths."""
+        pathString = node.get("d")
         if pathString:
-            id = node.get('id')
+            id = node.get("id")
             path = inkex.paths.CubicSuperPath(node.get("d"))
             transf = Transform(transform) * Transform(node.get("transform", None))
             path = Path(path).transform(transf).to_superpath()
             # reflection on y axys to have y growing toward up direction of the graph
             points[id] = [point[1] for segment in path for point in segment]
-            points[id] = [(x,-y) for (x,y) in points[id]]
+            points[id] = [(x, -y) for (x, y) in points[id]]
         elif node.tag == inkex.addNS("g", "svg"):
             transf = Transform(transform) * Transform(node.get("transform", None))
             for child in node.iterchildren():
-                self.extractPath(child, points, transf)
+                self.extract_path(child, points, transf)
         else:
             inkex.utils.debug(node.tag)
 
-    """ toXY effect. """
     def effect(self):
-        if len(self.svg.selected)<1:
-            inkex.utils.debug("This extension requires that you select at least one path.")
+        """toXY effect."""
+        if len(self.svg.selected) < 1:
+            inkex.utils.debug(
+                "This extension requires that you select at least one path."
+            )
             return
 
-        xrange = self.options.xmax-self.options.xmin
-        yrange = self.options.ymax-self.options.ymin
-        if xrange<=0 or yrange<=0:
+        xrange = self.options.xmax - self.options.xmin
+        yrange = self.options.ymax - self.options.ymin
+        if xrange <= 0 or yrange <= 0:
             inkex.utils.debug("Negative ranges, check x-y min-max values.")
             return
 
-        #gathering points from paths
+        # gathering points from paths
         points = {}
         for id in self.options.ids:
             node = self.svg.selected[id]
-            self.extractPath(node,points)
+            self.extract_path(node, points)
 
         if not points:
             inkex.utils.debug("No paths found.")
@@ -155,13 +154,17 @@ class ToXYEffect(inkex.Effect):
         for path_id, coordinates in points.items():
             points[path_id] = set(coordinates)
 
-        #boundaries
+        # boundaries
         xmin = min([point[0] for pointset in points.values() for point in pointset])
         ymin = min([point[1] for pointset in points.values() for point in pointset])
 
-        xdelta = max([point[0] for pointset in points.values() for point in pointset])-xmin
-        ydelta = max([point[1] for pointset in points.values() for point in pointset])-ymin
-        
+        xdelta = (
+            max([point[0] for pointset in points.values() for point in pointset]) - xmin
+        )
+        ydelta = (
+            max([point[1] for pointset in points.values() for point in pointset]) - ymin
+        )
+
         # converting coordinates writing table
         table = "pathId idx x y\n"
         for id in list(points.keys()):
@@ -181,12 +184,22 @@ class ToXYEffect(inkex.Effect):
 
             table += "\n"
 
-        #output
-        group = etree.SubElement(self.svg.get_current_layer(), inkex.addNS('g','svg'))
-        self.draw_rect(xmin, -ymin-ydelta, xdelta, ydelta,group)
-        self.write_text(xmin,-ymin+self.options.fontSize,"{0:4g},{1:4g}".format(self.options.xmin,self.options.ymin),group)
-        self.write_text(xmin+xdelta, -ymin-ydelta,"{0:4g},{1:4g}".format(self.options.xmax,self.options.ymax),group)
-        self.write_text(xmin, -ymin+self.options.fontSize*2.5, table,group)
+        # output
+        group = etree.SubElement(self.svg.get_current_layer(), inkex.addNS("g", "svg"))
+        self.draw_rect(xmin, -ymin - ydelta, xdelta, ydelta, group)
+        self.write_text(
+            xmin,
+            -ymin + self.options.fontSize,
+            "{0:4g},{1:4g}".format(self.options.xmin, self.options.ymin),
+            group,
+        )
+        self.write_text(
+            xmin + xdelta,
+            -ymin - ydelta,
+            "{0:4g},{1:4g}".format(self.options.xmax, self.options.ymax),
+            group,
+        )
+        self.write_text(xmin, -ymin + self.options.fontSize * 2.5, table, group)
 
         # optionally write to external output file
         if self.options.write_output_file:
@@ -195,6 +208,7 @@ class ToXYEffect(inkex.Effect):
                     f.write(table)
             except OSError as e:
                 inkex.utils.debug(e)
+
 
 e = ToXYEffect()
 e.run()


### PR DESCRIPTION
Dear Andrea,

Thank you for publishing this extension. As the extension interface of Inkscape changed quite a bit and also python 3 is now a requirement here is an updated version that also includes a save-to-file function and slightly enhanced output (center of paths in case the figure contains circles or similar elements). 

This does not yet contain any unit tests but worked fine in a few manual tests. In the future this could be extended to also work with logarithmic graphs but that is for another day. 

